### PR TITLE
Replace Dynamic with Static Content in my-license

### DIFF
--- a/docs/my-license/index.mdx
+++ b/docs/my-license/index.mdx
@@ -35,29 +35,11 @@ The license key installation process involves three steps:
 
 ## Download Your License Key
 
-*This section contains auto-generated content based on the license information for your account.*
+To download a license key for Kendo UI for Vue, you must have either a developer license or a trial license. If you are new to Kendo UI for Vue, [sign up for a free trial](https://www.telerik.com/download-trial-file/v2-b/kendo-vue-ui) first and then follow the steps below.
 
-<LicenseDownload
-  productCodes={['KENDOUIVUE', 'KENDOUICOMPLETE']}
-  productName="Kendo UI for Vue"
-  purchaseUrl="https://www.telerik.com/purchase/kendo-ui"
-  trialUrl="https://www.telerik.com/download-trial-file/v2-b/kendo-vue-ui"
->
-    <Button
-        as={'a'}
-        style={{display: 'inline-flex', textDecoration: 'none'}}
-        importance="secondary"
-        aria-label="Download link for Kendo UI for Vue license"
-        href="/kendo-vue-ui/components/my-license/download"
-        target="_blank"
-    >
-        <svg width="16px" height="16px" viewBox="0 0 512 512">
-            <path fill="#fff" d="M32,384L32,384v96h448v-96l0,0H32z M288,32h-64v128h-96l128,160l128-160h-96V32z"/>
-        </svg>
-        &nbsp;
-        kendo-ui-license.txt
-  </Button>
-</LicenseDownload>
+1. Go to the [License Keys](https://www.telerik.com/account/your-licenses/license-keys) page in your Telerik account.
+
+1. On the Progress® Kendo UI® for Vue row, click the Download key link in the **LICENSE KEY** column.
 
 ## Managing your License 
 

--- a/docs/my-license/index.mdx
+++ b/docs/my-license/index.mdx
@@ -39,7 +39,7 @@ To download a license key for Kendo UI for Vue, you must have either a developer
 
 1. Go to the [License Keys](https://www.telerik.com/account/your-licenses/license-keys) page in your Telerik account.
 
-1. On the Progress® Kendo UI® for Vue row, click the Download key link in the **LICENSE KEY** column.
+1. On the Progress® Kendo UI® for Vue row, click the **Download key** link in the **LICENSE KEY** column.
 
 ## Managing your License 
 


### PR DESCRIPTION
As the license files are available in Your Account, we need to update the documentation and make it point to the License Keys page where the developers will download the required files.