### PR TITLE
chore: deploy vite-coffee-warehouse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Builds and tests example applications
+# Builds and tests examples-standalone applications
 name: CI
 
 on:
@@ -7,32 +7,50 @@ on:
       - master
 
 env:
-  NODE_OPTIONS: --max_old_space_size=6144
+  NODE_OPTIONS: --max_old_space_size=16384
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
-      - name: Use NodeJS v14
-        uses: actions/setup-node@v2
+      - name: Use NodeJS v20
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Build Coffee warehouse app
-        working-directory: ./examples-standalone/coffee-warehouse
-        run: |
-          npm ci
-          npm run build
+      - name: Get changed files
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            dashboard:
+              - 'examples-standalone/dashboard/**'
+            vite-coffee-warehouse:
+              - 'examples-standalone/vite-coffee-warehouse/**'
+
+    #   - name: Build Coffee warehouse app
+    #     working-directory: ./examples-standalone/coffee-warehouse
+    #     run: |
+    #       npm ci
+    #       npm run build
 
       - name: Build Dashboard app
         working-directory: ./examples-standalone/dashboard
+        if: steps.changes.outputs.dashboard == 'true'
         run: |
           npm ci
           npm run build
+
+      - name: Build Vite Coffee warehouse app
+        working-directory: ./examples-standalone/vite-coffee-warehouse
+        if: steps.changes.outputs.vite-coffee-warehouse == 'true'
+        run: |
+            npm ci
+            npm run build
 
       - name: Cleanup
         run: git clean -xdf

--- a/examples-standalone/vite-coffee-warehouse/package-lock.json
+++ b/examples-standalone/vite-coffee-warehouse/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite-kendo-vue-coffee-warehouse",
+  "name": "vite-coffee-warehouse",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-kendo-vue-coffee-warehouse",
+      "name": "vite-coffee-warehouse",
       "version": "0.0.0",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
@@ -1900,9 +1900,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -2502,9 +2502,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
+      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2686,9 +2686,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001700",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
-      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
+      "version": "1.0.30001701",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
+      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
       "devOptional": true,
       "funding": [
         {
@@ -3094,9 +3094,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.102",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
-      "integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
+      "version": "1.5.105",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.105.tgz",
+      "integrity": "sha512-ccp7LocdXx3yBhwiG0qTQ7XFrK48Ua2pxIxBdJO8cbddp/MvbBtPFzvnTchtyHQTsgqqczO8cdmAIbpMa0u2+g==",
       "devOptional": true,
       "license": "ISC",
       "peer": true
@@ -3841,18 +3841,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -5145,9 +5145,9 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.1.tgz",
+      "integrity": "sha512-pfRR4ZcNTSm2ZFHaztuvbICf+hyiG6ecA06SfAxoPmuHjvMu0KUIae7Y8GyVkbBqeEIidsmXeYooWIX9+qjfRQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5601,9 +5601,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
-      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6077,9 +6077,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.85.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.0.tgz",
-      "integrity": "sha512-3ToiC1xZ1Y8aU7+CkgCI/tqyuPXEmYGJXO7H4uqp0xkLXUqp88rQQ4j1HmP37xSJLbCJPaIiv+cT1y+grssrww==",
+      "version": "1.85.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.1.tgz",
+      "integrity": "sha512-Uk8WpxM5v+0cMR0XjX9KfRIacmSG86RH4DCCZjLU2rFh5tyutt9siAXJ7G+YfxQ99Q6wrRMbMlVl6KqUms71ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples-standalone/vite-coffee-warehouse/package.json
+++ b/examples-standalone/vite-coffee-warehouse/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-kendo-vue-coffee-warehouse",
+  "name": "vite-coffee-warehouse",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/examples/bin/build-gh-pages
+++ b/examples/bin/build-gh-pages
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Builds example projects and deploys them to GH Pages
-STANDALONE_PROJECTS=(coffee-warehouse dashboard)
+STANDALONE_PROJECTS=(coffee-warehouse dashboard vite-coffee-warehouse)
 
 set -e
 

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -13,6 +13,7 @@
     <ul>
       <li><a href="coffee-warehouse/">Integrating Kendo UI for Vue with Progressive Web Applications (Material Design)</a></li>
       <li><a href="dashboard/">A demo project implementing the Grid, Chart, Drawer and other Kendo UI for Vue Native components</a></li>
+      <li><a href="vite-coffee-warehouse/">Coffee Warehouse Dashboard Vite Application</a></li>
     </ul>
     <p>
       To access the source code of all sample applications, go to the


### PR DESCRIPTION
Implements: 
https://github.com/telerik/kendo-vue-private/issues/2035
https://github.com/telerik/kendo-vue-private/issues/1993
 

- The pr has to deploy the new vite-coffe-warehouse app on a separate address apart from the original one (https://telerik.github.io/kendo-vue/coffee-warehouse/).

- There is an additional check in the `ci.yml` file that detects updated files and only builds the app that has been modified.