### PR TITLE
chore: update token permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,12 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     environment: github-pages
+    
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+      packages: read
 
     steps:
       - name: Use NodeJS v20


### PR DESCRIPTION
Adds the necessary token permissions for publish on github-pages. Cont'd #749