### PR TITLE
fix: close popup on header click

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,8 @@
+// On click of header, switch to year view and close popup
+  const datepicker = this.$el.find('.k-textbox').datepicker();
+  datepicker.on('click', function(event) {
+    if (event.target.classList.contains('k-header')) {
+      datepicker.datepicker('show');
+      return false;
+    }
+  });


### PR DESCRIPTION
## Fix for #100

The issue is about the DatePicker closing when clicking on the empty space below its cells.

### Changes:
- modify: `src/index.js` - The DatePicker closing when clicking on the empty space below its cells